### PR TITLE
Feature/initial settings

### DIFF
--- a/src/config/HttpConfig.cpp
+++ b/src/config/HttpConfig.cpp
@@ -18,7 +18,7 @@ ReturnDirective::ReturnDirective() : status(CommonConfig::INVALID_NUM) {}
 
 LocationConfig::LocationConfig() {
     allowed_methods_.push_back(MethodGET);
+    allowed_methods_.push_back(MethodHEAD);
     allowed_methods_.push_back(MethodPOST);
     allowed_methods_.push_back(MethodDELETE);
-    allowed_methods_.push_back(MethodHEAD);
 }

--- a/src/config/HttpConfig.h
+++ b/src/config/HttpConfig.h
@@ -74,6 +74,7 @@ struct CommonConfig {
 
 class LocationConfig {
    public:
+    LocationConfig();
     // ---setter---
     void setPath(const std::string& p) { path_ = p; }
     void setRoot(const std::string& r) {
@@ -105,8 +106,6 @@ class LocationConfig {
     void setAllowedMethods(const std::vector<Method>& methods) {
         allowed_methods_ = methods;  // ベクター全体を代入（上書き）
     }
-
-    LocationConfig();
 
     void setCgiPath(const std::string& p) { cgi_path_ = p; }
     void setCgiExtension(const std::string& e) { cgi_extension_ = e; }

--- a/src/config/HttpConfigParser.cpp
+++ b/src/config/HttpConfigParser.cpp
@@ -1,8 +1,9 @@
 #include "HttpConfigParser.h"
 
-#include <cctype>   // std::isspace
-#include <limits>   // std::numeric_limits を使うために必要
-#include <sstream>  //parseListen用
+#include <algorithm>  // std::findを使うためallowed_methods
+#include <cctype>     // std::isspace
+#include <limits>     // std::numeric_limits を使うために必要
+#include <sstream>    //parseListen用
 
 //構文解析用クラスkeyword
 const char* const HttpConfigParser::SPECIAL_CHARS = "{};";
@@ -37,8 +38,8 @@ const char* const HttpConfigParser::VALUE_OFF = "off";
 const char HttpConfigParser::SUFFIX_KILOBYTE = 'k';
 const char HttpConfigParser::SUFFIX_MEGABYTE = 'm';
 const char HttpConfigParser::SUFFIX_GIGABYTE = 'g';
-const char* HttpConfigParser::HTTP_PREFIX = "http://";
-const char* HttpConfigParser::HTTPS_PREFIX = "https://";
+const char* const HttpConfigParser::HTTP_PREFIX = "http://";
+const char* const HttpConfigParser::HTTPS_PREFIX = "https://";
 //終端に来たかどうか
 bool HttpConfigParser::isEof(const std::vector<std::string>& tokens,
                              size_t index) {
@@ -622,7 +623,7 @@ ReturnDirective HttpConfigParser::parseReturn(
     if (getNextToken(tokens, index) != SEMICOLON) {
         throw std::runtime_error("Error: Expected ';' after return directive");
     }
-    // 5. 2番目の引数が URL/パス か、ただのテキストかを判定
+    // 2番目の引数が URL/パス か、ただのテキストかを判定
     if (next_token.find('/') == 0 || next_token.find(HTTP_PREFIX) == 0 ||
         next_token.find(HTTPS_PREFIX) == 0) {
         rd.target = next_token;  // URL or Path
@@ -675,17 +676,25 @@ std::vector<Method> HttpConfigParser::parseAllowedMethods(
         if (token == SEMICOLON) {
             break;
         }
+
+        // 文字列を Method enum に変換
+        Method m;
         if (token == "GET") {
-            methods.push_back(MethodGET);
+            m = MethodGET;
         } else if (token == "POST") {
-            methods.push_back(MethodPOST);
+            m = MethodPOST;
         } else if (token == "DELETE") {
-            methods.push_back(MethodDELETE);
+            m = MethodDELETE;
         } else if (token == "HEAD") {
-            methods.push_back(MethodHEAD);
+            m = MethodHEAD;
         } else {
             throw std::runtime_error(
                 "Error: Unknown method in allow_methods: " + token);
+        }
+
+        //重複チェックex)[GET,GET]にならないように
+        if (std::find(methods.begin(), methods.end(), m) == methods.end()) {
+            methods.push_back(m);
         }
     }
     if (methods.empty()) {

--- a/src/config/HttpConfigParser.h
+++ b/src/config/HttpConfigParser.h
@@ -148,8 +148,8 @@ class HttpConfigParser {
     static const char SUFFIX_MEGABYTE;
     static const char SUFFIX_GIGABYTE;
 
-    static const char* HTTP_PREFIX;
-    static const char* HTTPS_PREFIX;
+    static const char* const HTTP_PREFIX;
+    static const char* const HTTPS_PREFIX;
 
     // マジックナンバー定数に
     static const off_t BYTES_PER_KB = 1024;


### PR DESCRIPTION
## 概要
 Location Config のコンストラクタで allowedMethods を GET, HEAD, POST, DELETE で初期化するようにしました。
<!-- Issue があれば記載 -->
<!-- PRの概要と実施背景を記載 -->

## 変更点
HttpConfig.h
・LocationConfig();デフォルトコンストラクタの宣言を追加
HttpConfig.cpp
・allowed_methods_.push_back(MethodGET);
・allowed_methods_.push_back(MethodPOST);
・allowed_methods_.push_back(MethodDELETE);
・allowed_methods_.push_back(MethodHEAD);の追加
<!-- コードの変更点を明記 -->

## 影響範囲・懸念点

<!-- 影響が及びそうな範囲、レビューしてほしい点を記載 -->

## 動作確認

<!-- 実施した動作確認 -->
<!-- レビュイーのために実際のコマンドなどあると◯ -->

## その他
