### PR TITLE
no_new_line でコンパイルエラーになる不具合を修正

### DIFF
--- a/src/config/HttpConfig.cpp
+++ b/src/config/HttpConfig.cpp
@@ -22,4 +22,3 @@ LocationConfig::LocationConfig() {
     allowed_methods_.push_back(MethodPOST);
     allowed_methods_.push_back(MethodDELETE);
 }
-

--- a/src/config/HttpConfigParser.cpp
+++ b/src/config/HttpConfigParser.cpp
@@ -739,4 +739,3 @@ std::vector<std::string> HttpConfigParser::parseServerName(
     }
     return server_names;
 }
-

--- a/src/config/HttpConfigParser.h
+++ b/src/config/HttpConfigParser.h
@@ -191,4 +191,3 @@ class HttpConfigParser {
         return true;
     }
 };
-


### PR DESCRIPTION
## 概要
校舎環境でコンパイルエラーだったため修正
clang だとファイル末尾に改行がないと警告を出すらしい
自分の PC だと gcc でコンパイルしてるためコンパイルできる。
```
In file included from src/config/HttpConfigParser.cpp:1:
src/config/HttpConfigParser.h:193:3: error: no newline at end of file [-Werror,-Wnewline-eof]
};
  ^
1 error generated.
make: *** [Makefile:49: src/config/HttpConfigParser.o] Error 1
```
<!-- Issue があれば記載 -->
<!-- PRの概要と実施背景を記載 -->

## 変更点
- 改行追加
<!-- コードの変更点を明記 -->

## 動作確認
```
yehara % make re && echo OK
rm -f src/cgi/executor_cgi.o src/cgi/handler_cgi.o src/cgi/request_cgi.o src/cgi/response_cgi.o src/config/HttpConfig.o src/config/HttpConfigParser.o src/core/Common.o src/core/main.o src/core/Server.o src/core/String.o src/event/Event.o src/http/ClientHandler.o src/http/HttpDate.o src/http/HttpException.o src/http/HttpParser.o src/http/HttpResponse.o src/http/MimeTypes.o src/http/ResolveConfig.o src/http/ResponseFactory.o src/http/Router.o test/test.o src/cgi/handler_cgi.o src/cgi/request_cgi.o src/cgi/response_cgi.o src/cgi/executor_cgi.o src/core/Common.o src/http/HttpParser.o src/core/String.o src/http/HttpException.o
rm -f webserv cgi_test_runner
c++ -Wall -Wextra -Werror -std=c++98 -pedantic -g -c src/cgi/executor_cgi.cpp -o src/cgi/executor_cgi.o
c++ -Wall -Wextra -Werror -std=c++98 -pedantic -g -c src/cgi/handler_cgi.cpp -o src/cgi/handler_cgi.o
c++ -Wall -Wextra -Werror -std=c++98 -pedantic -g -c src/cgi/request_cgi.cpp -o src/cgi/request_cgi.o
c++ -Wall -Wextra -Werror -std=c++98 -pedantic -g -c src/cgi/response_cgi.cpp -o src/cgi/response_cgi.o
c++ -Wall -Wextra -Werror -std=c++98 -pedantic -g -c src/config/HttpConfig.cpp -o src/config/HttpConfig.o
c++ -Wall -Wextra -Werror -std=c++98 -pedantic -g -c src/config/HttpConfigParser.cpp -o src/config/HttpConfigParser.o
c++ -Wall -Wextra -Werror -std=c++98 -pedantic -g -c src/core/Common.cpp -o src/core/Common.o
c++ -Wall -Wextra -Werror -std=c++98 -pedantic -g -c src/core/main.cpp -o src/core/main.o
c++ -Wall -Wextra -Werror -std=c++98 -pedantic -g -c src/core/Server.cpp -o src/core/Server.o
c++ -Wall -Wextra -Werror -std=c++98 -pedantic -g -c src/core/String.cpp -o src/core/String.o
c++ -Wall -Wextra -Werror -std=c++98 -pedantic -g -c src/event/Event.cpp -o src/event/Event.o
c++ -Wall -Wextra -Werror -std=c++98 -pedantic -g -c src/http/ClientHandler.cpp -o src/http/ClientHandler.o
c++ -Wall -Wextra -Werror -std=c++98 -pedantic -g -c src/http/HttpDate.cpp -o src/http/HttpDate.o
c++ -Wall -Wextra -Werror -std=c++98 -pedantic -g -c src/http/HttpException.cpp -o src/http/HttpException.o
c++ -Wall -Wextra -Werror -std=c++98 -pedantic -g -c src/http/HttpParser.cpp -o src/http/HttpParser.o
c++ -Wall -Wextra -Werror -std=c++98 -pedantic -g -c src/http/HttpResponse.cpp -o src/http/HttpResponse.o
c++ -Wall -Wextra -Werror -std=c++98 -pedantic -g -c src/http/MimeTypes.cpp -o src/http/MimeTypes.o
c++ -Wall -Wextra -Werror -std=c++98 -pedantic -g -c src/http/ResolveConfig.cpp -o src/http/ResolveConfig.o
c++ -Wall -Wextra -Werror -std=c++98 -pedantic -g -c src/http/ResponseFactory.cpp -o src/http/ResponseFactory.o
c++ -Wall -Wextra -Werror -std=c++98 -pedantic -g -c src/http/Router.cpp -o src/http/Router.o
c++ -Wall -Wextra -Werror -std=c++98 -pedantic -g -o webserv src/cgi/executor_cgi.o src/cgi/handler_cgi.o src/cgi/request_cgi.o src/cgi/response_cgi.o src/config/HttpConfig.o src/config/HttpConfigParser.o src/core/Common.o src/core/main.o src/core/Server.o src/core/String.o src/event/Event.o src/http/ClientHandler.o src/http/HttpDate.o src/http/HttpException.o src/http/HttpParser.o src/http/HttpResponse.o src/http/MimeTypes.o src/http/ResolveConfig.o src/http/ResponseFactory.o src/http/Router.o
OK
```
<!-- 実施した動作確認 -->
<!-- レビュイーのために実際のコマンドなどあると◯ -->