### PR TITLE
Fd 関係のリファクタリング

### DIFF
--- a/src/cgi/executor_cgi.cpp
+++ b/src/cgi/executor_cgi.cpp
@@ -30,10 +30,10 @@ CgiExecutor::CgiExecutor() {
 }
 
 CgiExecutor::~CgiExecutor() {
-    safeClose(pipeIn_[0]);
-    safeClose(pipeIn_[1]);
-    safeClose(pipeOut_[0]);
-    safeClose(pipeOut_[1]);
+    fd::Fd::close(pipeIn_[0]);
+    fd::Fd::close(pipeIn_[1]);
+    fd::Fd::close(pipeOut_[0]);
+    fd::Fd::close(pipeOut_[1]);
 }
 
 CgiResult CgiExecutor::execute(const std::string &scriptPath,
@@ -44,8 +44,8 @@ CgiResult CgiExecutor::execute(const std::string &scriptPath,
     }
 
     if (pipe(pipeOut_) == -1) {
-        safeClose(pipeIn_[0]);
-        safeClose(pipeIn_[1]);
+        fd::Fd::close(pipeIn_[0]);
+        fd::Fd::close(pipeIn_[1]);
         throw CgiExecutionException("Failed to create stdout pipe",
                                     HttpStatus::InternalServerError);
     }
@@ -55,10 +55,10 @@ CgiResult CgiExecutor::execute(const std::string &scriptPath,
 
     pid_ = fork();
     if (pid_ == -1) {
-        safeClose(pipeIn_[0]);
-        safeClose(pipeIn_[1]);
-        safeClose(pipeOut_[0]);
-        safeClose(pipeOut_[1]);
+        fd::Fd::close(pipeIn_[0]);
+        fd::Fd::close(pipeIn_[1]);
+        fd::Fd::close(pipeOut_[0]);
+        fd::Fd::close(pipeOut_[1]);
         throw CgiExecutionException("Failed to fork",
                                     HttpStatus::InternalServerError);
     }
@@ -68,8 +68,8 @@ CgiResult CgiExecutor::execute(const std::string &scriptPath,
         exit(EXIT_FAILURE);
     }
 
-    safeClose(pipeIn_[0]);
-    safeClose(pipeOut_[1]);
+    fd::Fd::close(pipeIn_[0]);
+    fd::Fd::close(pipeOut_[1]);
     CgiResult result;
     result.pid = pid_;
     result.readFd = pipeOut_[0];
@@ -83,7 +83,7 @@ CgiResult CgiExecutor::execute(const std::string &scriptPath,
 int CgiExecutor::initializeEpoll(int pipe_fd) {
     int epoll_fd = epoll_create(1);
     if (epoll_fd == -1) {
-        safeClose(pipe_fd);
+        fd::Fd::close(pipe_fd);
         throw CgiExecutionException("epoll_create failed",
                                     HttpStatus::InternalServerError);
     }
@@ -92,8 +92,8 @@ int CgiExecutor::initializeEpoll(int pipe_fd) {
     ev.events = EPOLLIN | EPOLLHUP | EPOLLERR;
     ev.data.fd = pipe_fd;
     if (epoll_ctl(epoll_fd, EPOLL_CTL_ADD, pipe_fd, &ev) == -1) {
-        safeClose(pipe_fd);
-        safeClose(epoll_fd);
+        fd::Fd::close(pipe_fd);
+        fd::Fd::close(epoll_fd);
         throw CgiExecutionException("epoll_ctl failed",
                                     HttpStatus::InternalServerError);
     }
@@ -102,23 +102,23 @@ int CgiExecutor::initializeEpoll(int pipe_fd) {
 
 void CgiExecutor::executeChildProcess(const std::string &scriptPath,
                                       char *const argv[], char *const envp[]) {
-    safeClose(pipeIn_[1]);
+    fd::Fd::close(pipeIn_[1]);
     if (dup2(pipeIn_[0], STDIN_FILENO) == -1) {
         std::cerr << "CGI Error: dup2 failed for stdin\n";
-        safeClose(pipeIn_[0]);
-        safeClose(pipeOut_[0]);
-        safeClose(pipeOut_[1]);
+        fd::Fd::close(pipeIn_[0]);
+        fd::Fd::close(pipeOut_[0]);
+        fd::Fd::close(pipeOut_[1]);
         return;
     }
-    safeClose(pipeIn_[0]);
+    fd::Fd::close(pipeIn_[0]);
 
-    safeClose(pipeOut_[0]);
+    fd::Fd::close(pipeOut_[0]);
     if (dup2(pipeOut_[1], STDOUT_FILENO) == -1) {
         std::cerr << "CGI Error: dup2 failed for stdout\n";
-        safeClose(pipeOut_[1]);
+        fd::Fd::close(pipeOut_[1]);
         return;
     }
-    safeClose(pipeOut_[1]);
+    fd::Fd::close(pipeOut_[1]);
 
     std::string dir = getScriptDirectory(scriptPath);
     if (chdir(dir.c_str()) == -1) {
@@ -146,22 +146,6 @@ void CgiExecutor::checkChildExitStatus(int status) {
                                     HttpStatus::InternalServerError);
     }
     throw CgiExecutionException("CGI crashed", HttpStatus::InternalServerError);
-}
-
-void CgiExecutor::safeClose(int &fd) {
-    if (fd == -1) {
-        return;
-    }
-
-    int tmp_fd = fd;
-    fd = -1;
-
-    if (close(tmp_fd) == -1) {
-        std::stringstream ss;
-        ss << "Failed CgiExecutor close(" << tmp_fd << ")";
-
-        perror(ss.str().c_str());
-    }
 }
 
 std::string CgiExecutor::getScriptDirectory(const std::string &scriptPath) {

--- a/src/cgi/executor_cgi.cpp
+++ b/src/cgi/executor_cgi.cpp
@@ -14,6 +14,7 @@
 #include <string>
 
 #include "../core/Common.h"
+#include "../core/Socket.h"
 
 namespace {
 const int CGI_TIMEOUT_MS = 5000;
@@ -49,8 +50,8 @@ CgiResult CgiExecutor::execute(const std::string &scriptPath,
                                     HttpStatus::InternalServerError);
     }
 
-    Socket::set_nonblocking(pipeIn_[1]);   // 親が書き込む方
-    Socket::set_nonblocking(pipeOut_[0]);  // 親が読み込む方
+    fd::Socket::set_nonblocking(pipeIn_[1]);   // 親が書き込む方
+    fd::Socket::set_nonblocking(pipeOut_[0]);  // 親が読み込む方
 
     pid_ = fork();
     if (pid_ == -1) {

--- a/src/cgi/executor_cgi.h
+++ b/src/cgi/executor_cgi.h
@@ -39,7 +39,6 @@ class CgiExecutor {
 
     CgiResult execute(const std::string &scriptPath, char *const argv[],
                       char *const envp[]);
-    static void safeClose(int &fd);
 
    private:
     pid_t pid_;

--- a/src/core/Common.cpp
+++ b/src/core/Common.cpp
@@ -6,14 +6,12 @@
 #include <cstring>
 #include <stdexcept>
 
+#include "Socket.h"
+
 // 定数
 const char* const HTTP_VERSION = "HTTP/1.1";
 const uint16_t DEFAULT_PORT = 8080;
 const char* const DEFAULT_ADDRESS = "0.0.0.0";
-const int SOCKET_DOMAIN = AF_INET;
-const int SOCKET_TYPE = SOCK_STREAM;
-const int SOCKET_PROTOCOL = 0;
-const int SOCKET_BACKLOG = 128;
 const char* const HTTP_LINE_END = "\r\n";
 const char* const COLON = ":";
 const std::vector<std::string>::size_type HEADER_FIELD_NUM = 2;
@@ -78,7 +76,7 @@ bool HostHeader::resolve_ipv4(const std::string& host, uint16_t port,
     struct addrinfo* res = NULL;
 
     std::memset(&hints, 0, sizeof(hints));
-    hints.ai_family = SOCKET_DOMAIN;
+    hints.ai_family = fd::Socket::SOCKET_DOMAIN;
     hints.ai_socktype = SOCK_STREAM;
 
     int ret = getaddrinfo(host.c_str(), NULL, &hints, &res);
@@ -97,80 +95,6 @@ bool HostHeader::resolve_ipv4(const std::string& host, uint16_t port,
 
 const std::string& HostHeader::getAddress() const { return address_; }
 uint16_t HostHeader::getPort() const { return port_; }
-
-Socket::Socket() {
-    fd_ = ::socket(SOCKET_DOMAIN, SOCKET_TYPE, SOCKET_PROTOCOL);
-    if (fd_ < 0) {
-        throw std::runtime_error("socket failed: " +
-                                 std::string(strerror(errno)));
-    }
-}
-
-Socket::~Socket() {
-    if (fd_ >= 0) {
-        ::close(fd_);
-    }
-}
-
-Socket Socket::listen_tcp(const std::string& host, uint16_t port) {
-    Socket server_fd;
-    sockaddr_in addr = {};
-    if (!HostHeader::resolve_ipv4(host, port, addr)) {
-        throw std::runtime_error("resolve_ipv4 failed");
-    }
-
-    int yes = 1;
-    if (setsockopt(server_fd.fd_, SOL_SOCKET, SO_REUSEADDR, &yes, sizeof(yes)) <
-        0) {
-        throw std::runtime_error("setsockopt(SO_REUSEADDR) failed");
-    }
-
-    if (::bind(server_fd.fd_, reinterpret_cast<sockaddr*>(&addr),
-               sizeof(addr)) == -1) {
-        throw std::runtime_error("bind failed: " +
-                                 std::string(strerror(errno)));
-    }
-    if (::listen(server_fd.fd_, SOCKET_BACKLOG) == -1) {
-        throw std::runtime_error("listen failed: " +
-                                 std::string(strerror(errno)));
-    }
-
-    return server_fd;
-}
-
-Socket::Socket(const Socket& other) : fd_(-1) {
-    if (other.fd_ >= 0) {
-        int new_fd = ::dup(other.fd_);
-        if (new_fd == -1) {
-            throw std::runtime_error("dup failed: " +
-                                     std::string(strerror(errno)));
-        }
-        fd_ = new_fd;
-    }
-}
-
-Socket& Socket::operator=(const Socket& rhs) {
-    if (this == &rhs) {
-        return *this;
-    }
-    Socket tmp(rhs);
-    std::swap(fd_, tmp.fd_);
-    return *this;
-}
-
-int Socket::getFd() const { return fd_; }
-
-void Socket::set_nonblocking(int fd) {  // NOLINT
-    int flags = fcntl(fd, F_GETFL, 0);
-    if (flags == -1) {
-        throw std::runtime_error("fcntl failed: " +
-                                 std::string(strerror(errno)));
-    }
-    if (fcntl(fd, F_SETFL, flags | O_NONBLOCK) == -1) {
-        throw std::runtime_error("fcntl failed: " +
-                                 std::string(strerror(errno)));
-    }
-}
 
 Method string_to_method(const std::string& method_str) {
     if (method_str == "GET") return MethodGET;

--- a/src/core/Common.h
+++ b/src/core/Common.h
@@ -23,10 +23,6 @@ typedef unsigned short uint16_t;
 extern const char* const HTTP_VERSION;
 extern const uint16_t DEFAULT_PORT;
 extern const char* const DEFAULT_ADDRESS;
-extern const int SOCKET_DOMAIN;
-extern const int SOCKET_TYPE;
-extern const int SOCKET_PROTOCOL;
-extern const int SOCKET_BACKLOG;
 extern const char* const CONTENT_LENGTH;
 extern const char* const TRANSFER_ENCODING;
 extern const char* const CHUNKED;
@@ -94,18 +90,4 @@ class HostHeader {
    private:
     std::string address_;
     uint16_t port_;
-};
-
-class Socket {
-   public:
-    static Socket listen_tcp(const std::string& host, uint16_t port);
-    int getFd() const;
-    Socket& operator=(const Socket& rhs);
-    Socket(const Socket&);
-    ~Socket();
-    static void set_nonblocking(int fd);
-
-   private:
-    int fd_;
-    Socket();
 };

--- a/src/core/Fd.cpp
+++ b/src/core/Fd.cpp
@@ -11,52 +11,52 @@
 
 #include "fcntl.h"
 
-Fd::Fd(const char* filename, int flags, mode_t mode) : fd_(-1) {
+fd::Fd::Fd(const char* filename, int flags, mode_t mode) : fd_(Fd::DEFAULT_FD) {
     fd_ = ::open(filename, flags, mode);
-    if (fd_ == -1) {
-        throw OpenException("Failed to open file '" + std::string(filename) +
+    if (fd_ == Fd::DEFAULT_FD) {
+        throw fd::Exception("Failed to open file '" + std::string(filename) +
                             "': " + std::string(strerror(errno)));
     }
 }
 
-int Fd::getFd() const { return fd_; }
+int fd::Fd::getFd() const { return fd_; }
 
-std::vector<char> Fd::FreadAll() const {
-    std::vector<char> result;
-    char buf[DEFAULT_BUFFER_SIZE];
+void fd::Fd::readAll(std::vector<char>& response) const {
+    response.clear();
+    char buf[Fd::DEFAULT_BUFFER_SIZE];
 
     while (true) {
-        ssize_t len = ::read(fd_, buf, DEFAULT_BUFFER_SIZE);
+        ssize_t len = ::read(fd_, buf, Fd::DEFAULT_BUFFER_SIZE);
         if (len == -1) {
-            throw std::runtime_error("read() failed: " +
-                                     std::string(strerror(errno)));
+            throw std::runtime_error(
+                std::string("read() failed: ").append(strerror(errno)));
         }
         if (len == 0) break;
-        result.insert(result.end(), buf, buf + len);
+        response.insert(response.end(), buf, buf + len);
     }
-    return result;
 }
 
-void Fd::FwriteAll(const std::string& buf) const {
+void fd::Fd::writeAll(const std::string& buf) const {
     std::string::size_type total_written = 0;
     std::string::size_type buf_size = buf.size();
     while (total_written < buf_size) {
         ssize_t len =
             ::write(fd_, buf.c_str() + total_written, buf_size - total_written);
         if (len == -1)
-            throw std::runtime_error("write() failed: " +
-                                     std::string(strerror(errno)));
+            throw std::runtime_error(
+                std::string("write() failed: ").append((strerror(errno))));
         if (len == 0)
             throw std::runtime_error("write() returned 0 unexpectedly");
         total_written += static_cast<std::string::size_type>(len);
     }
 }
 
-Fd::~Fd() {
-    if (fd_ != -1) {
-        ::close(fd_);
-    }
+void fd::Fd::close(int fd) {
+    if (fd == Fd::DEFAULT_FD) return;
+    ::close(fd);
 }
 
-OpenException::OpenException(const std::string& message)
+fd::Fd::~Fd() { Fd::close(this->fd_); }
+
+fd::Exception::Exception(const std::string& message)
     : std::runtime_error(message) {}

--- a/src/core/Fd.cpp
+++ b/src/core/Fd.cpp
@@ -14,7 +14,7 @@
 
 fd::Fd::Fd() { fd_ = Fd::DEFAULT_FD; }
 
-fd::Fd::Fd(const Fd& other) {
+fd::Fd::Fd(const Fd& other) : fd_(Fd::DEFAULT_FD) {
     if (other.fd_ >= 0) {
         int new_fd = ::dup(other.fd_);
         if (new_fd == -1) {

--- a/src/core/Fd.cpp
+++ b/src/core/Fd.cpp
@@ -9,13 +9,29 @@
 #include <string>
 #include <vector>
 
+#include "FdException.h"
 #include "fcntl.h"
+
+fd::Fd::Fd() { fd_ = Fd::DEFAULT_FD; }
+
+fd::Fd::Fd(const Fd& other) {
+    if (other.fd_ >= 0) {
+        int new_fd = ::dup(other.fd_);
+        if (new_fd == -1) {
+            throw std::runtime_error(
+                std::string("dup failed: ").append(strerror(errno)));
+        }
+        fd_ = new_fd;
+    }
+}
 
 fd::Fd::Fd(const char* filename, int flags, mode_t mode) : fd_(Fd::DEFAULT_FD) {
     fd_ = ::open(filename, flags, mode);
     if (fd_ == Fd::DEFAULT_FD) {
-        throw fd::Exception("Failed to open file '" + std::string(filename) +
-                            "': " + std::string(strerror(errno)));
+        throw fd::Exception(std::string("Failed to open file '")
+                                .append(filename)
+                                .append("': ")
+                                .append(strerror(errno)));
     }
 }
 
@@ -57,6 +73,3 @@ void fd::Fd::close(int fd) {
 }
 
 fd::Fd::~Fd() { Fd::close(this->fd_); }
-
-fd::Exception::Exception(const std::string& message)
-    : std::runtime_error(message) {}

--- a/src/core/Fd.h
+++ b/src/core/Fd.h
@@ -9,24 +9,23 @@
 #include <vector>
 
 namespace fd {
-class Exception : public std::runtime_error {
-   public:
-    explicit Exception(const std::string& message);
-};
-
 class Fd {
    private:
     static const int DEFAULT_BUFFER_SIZE = 4096;
     static const mode_t DEFAULT_MODE =
         0777;  // umask
                // で制限をかけることを前提とするため、フルアクセスに設定する
+
+   protected:
     static const int DEFAULT_FD = -1;
 
-    int fd_;
+    int fd_;  // NOLINT
 
    public:
     static void close(int fd);
 
+    Fd();
+    Fd(const Fd&);
     Fd(const char* filename, int flags, mode_t mode = DEFAULT_MODE);
     ~Fd();
 
@@ -35,8 +34,6 @@ class Fd {
     void writeAll(const std::string&) const;
 
    private:
-    Fd();
-    Fd(const Fd&);
     Fd& operator=(const Fd&);
 };
 }  // namespace fd

--- a/src/core/Fd.h
+++ b/src/core/Fd.h
@@ -8,24 +8,35 @@
 #include <string>
 #include <vector>
 
-class OpenException : public std::runtime_error {
+namespace fd {
+class Exception : public std::runtime_error {
    public:
-    explicit OpenException(const std::string& message);
+    explicit Exception(const std::string& message);
 };
 
 class Fd {
+   private:
+    static const int DEFAULT_BUFFER_SIZE = 4096;
+    static const mode_t DEFAULT_MODE =
+        0777;  // umask
+               // で制限をかけることを前提とするため、フルアクセスに設定する
+    static const int DEFAULT_FD = -1;
+
+    int fd_;
+
    public:
+    static void close(int fd);
+
     Fd(const char* filename, int flags, mode_t mode = DEFAULT_MODE);
     ~Fd();
+
     int getFd() const;
-    std::vector<char> FreadAll() const;
-    void FwriteAll(const std::string&) const;
+    void readAll(std::vector<char>& response) const;
+    void writeAll(const std::string&) const;
 
    private:
     Fd();
     Fd(const Fd&);
     Fd& operator=(const Fd&);
-    int fd_;
-    static const int DEFAULT_BUFFER_SIZE = 4096;
-    static const mode_t DEFAULT_MODE = 0644;
 };
+}  // namespace fd

--- a/src/core/FdException.cpp
+++ b/src/core/FdException.cpp
@@ -1,0 +1,4 @@
+#include "FdException.h"
+
+fd::Exception::Exception(const std::string& message)
+    : std::runtime_error(message) {}

--- a/src/core/FdException.h
+++ b/src/core/FdException.h
@@ -1,0 +1,10 @@
+#pragma once
+
+#include <stdexcept>
+
+namespace fd {
+class Exception : public std::runtime_error {
+   public:
+    explicit Exception(const std::string& message);
+};
+}  // namespace fd

--- a/src/core/Server.cpp
+++ b/src/core/Server.cpp
@@ -3,8 +3,8 @@
 #include "../http/ClientHandler.h"
 
 Server::Server(Event& event, Router& router, const ServerConfig& server_config)
-    : listen_(Socket::listen_tcp(server_config.getListens().address,
-                                 server_config.getListens().port)),
+    : listen_(fd::Socket::listen_tcp(server_config.getListens().address,
+                                     server_config.getListens().port)),
       event_(event),
       router_(router),
       server_config_(server_config) {}
@@ -23,7 +23,7 @@ void Server::on_acceptable(int fd, uint32_t event, void* self) {  // NOLINT
         accept(fd, reinterpret_cast<struct sockaddr*>(&client), &len);
     if (client_fd == -1) return;
     std::cout << "accepted\n";
-    Socket::set_nonblocking(client_fd);
+    fd::Socket::set_nonblocking(client_fd);
     ClientHandler* handler = new ClientHandler(
         client_fd, server->event_, server->router_, server->server_config_);
     server->event_.add(client_fd, event,

--- a/src/core/Server.h
+++ b/src/core/Server.h
@@ -9,6 +9,7 @@
 #include "../event/Event.h"
 #include "../http/Router.h"
 #include "Common.h"
+#include "Socket.h"
 
 class Server {
    public:
@@ -16,7 +17,7 @@ class Server {
     void start();
 
    private:
-    Socket listen_;
+    const fd::Socket listen_;
     Event& event_;
     Router& router_;
     const ServerConfig server_config_;

--- a/src/core/Socket.cpp
+++ b/src/core/Socket.cpp
@@ -1,0 +1,68 @@
+#include "Socket.h"
+
+#include <netdb.h>
+
+#include <cstring>
+#include <stdexcept>
+
+#include "Common.h"
+#include "Fd.h"
+
+fd::Socket::Socket() {
+    this->fd_ = ::socket(SOCKET_DOMAIN, SOCKET_TYPE, SOCKET_PROTOCOL);
+    if (fd_ == -1) {
+        throw std::runtime_error(
+            std::string("socket failed: ").append(strerror(errno)));
+    }
+}
+
+fd::Socket::Socket(const Socket& other) : Fd(other) {
+    if (other.fd_ >= 0) {
+        int new_fd = ::dup(other.fd_);
+        if (new_fd == -1) {
+            throw std::runtime_error(
+                std::string("dup failed: ").append(strerror(errno)));
+        }
+        fd_ = new_fd;
+    }
+}
+
+fd::Socket::~Socket() { fd::Fd::close(fd_); }
+
+fd::Socket fd::Socket::listen_tcp(const std::string& host, uint16_t port) {
+    fd::Socket server_fd;
+    sockaddr_in addr = {};
+    if (!HostHeader::resolve_ipv4(host, port, addr)) {
+        throw std::runtime_error("resolve_ipv4 failed");
+    }
+
+    int yes = 1;
+    if (setsockopt(server_fd.fd_, SOL_SOCKET, SO_REUSEADDR, &yes, sizeof(yes)) <
+        0) {
+        throw std::runtime_error("setsockopt(SO_REUSEADDR) failed");
+    }
+
+    if (::bind(server_fd.fd_, reinterpret_cast<sockaddr*>(&addr),
+               sizeof(addr)) == -1) {
+        throw std::runtime_error(
+            std::string("bind failed: ").append(strerror(errno)));
+    }
+    if (::listen(server_fd.fd_, SOCKET_BACKLOG) == -1) {
+        throw std::runtime_error(
+            std::string("listen failed: ").append(strerror(errno)));
+    }
+    return server_fd;
+}
+
+void fd::Socket::set_nonblocking(int fd) {
+    if (fd == fd::Fd::DEFAULT_FD) return;
+    int flags = fcntl(fd, F_GETFL, 0);
+    if (flags == -1) {
+        throw std::runtime_error(
+            std::string("fcntl failed: ").append(strerror(errno)));
+    }
+    if (fcntl(fd, F_SETFL, flags | O_NONBLOCK) == -1) {
+        throw std::runtime_error(
+            std::string("fcntl failed: ").append(strerror(errno)));
+    }
+}

--- a/src/core/Socket.cpp
+++ b/src/core/Socket.cpp
@@ -16,18 +16,9 @@ fd::Socket::Socket() {
     }
 }
 
-fd::Socket::Socket(const Socket& other) : Fd(other) {
-    if (other.fd_ >= 0) {
-        int new_fd = ::dup(other.fd_);
-        if (new_fd == -1) {
-            throw std::runtime_error(
-                std::string("dup failed: ").append(strerror(errno)));
-        }
-        fd_ = new_fd;
-    }
-}
+fd::Socket::Socket(const Socket& other) : Fd(other) {}
 
-fd::Socket::~Socket() { fd::Fd::close(fd_); }
+fd::Socket::~Socket() {}
 
 fd::Socket fd::Socket::listen_tcp(const std::string& host, uint16_t port) {
     fd::Socket server_fd;

--- a/src/core/Socket.h
+++ b/src/core/Socket.h
@@ -1,0 +1,29 @@
+#pragma once
+
+#include <sys/socket.h>
+
+#include <string>
+
+#include "Common.h"
+#include "Fd.h"
+
+namespace fd {
+class Socket : public Fd {
+   private:
+    static const int SOCKET_TYPE = SOCK_STREAM;
+    static const int SOCKET_PROTOCOL = 0;
+    static const int SOCKET_BACKLOG = 128;
+
+   public:
+    static const int SOCKET_DOMAIN = AF_INET;
+    Socket();
+    Socket(const Socket&);
+    ~Socket();
+
+    static Socket listen_tcp(const std::string& host, uint16_t port);
+    static void set_nonblocking(int fd);
+
+   private:
+    Socket& operator=(const Socket&);
+};
+}  // namespace fd

--- a/src/event/Event.cpp
+++ b/src/event/Event.cpp
@@ -4,6 +4,7 @@
 
 #include <cstring>
 
+#include "../core/Fd.h"
 #include "../http/ClientHandler.h"
 
 Event::Event() {
@@ -89,7 +90,7 @@ void Event::run() {  // NOLINT
 
 Event::~Event() {
     if (epoll_fd_ >= 0) {
-        ::close(epoll_fd_);
+        fd::Fd::close(epoll_fd_);
     }
     for (std::map<int, EventData*>::iterator it = registry_.begin();
          it != registry_.end(); ++it) {

--- a/src/http/ClientHandler.cpp
+++ b/src/http/ClientHandler.cpp
@@ -9,6 +9,7 @@
 #include <cstring>
 #include <ctime>
 
+#include "../core/Fd.h"
 #include "../core/String.h"
 #include "HttpException.h"
 #include "ResponseFactory.h"
@@ -56,12 +57,12 @@ void ClientHandler::check_cgi_timeout() {
         // 2. パイプのクローズと監視削除
         if (cgi_session_.readFd != -1) {
             event_.del(cgi_session_.readFd);
-            close(cgi_session_.readFd);
+            fd::Fd::close(cgi_session_.readFd);
             cgi_session_.readFd = -1;
         }
         if (cgi_session_.writeFd != -1) {
             event_.del(cgi_session_.writeFd);
-            close(cgi_session_.writeFd);
+            fd::Fd::close(cgi_session_.writeFd);
             cgi_session_.writeFd = -1;
         }
 
@@ -106,11 +107,11 @@ void ClientHandler::on_close() {
     }
     if (cgi_session_.readFd != -1) {
         event_.del(cgi_session_.readFd);
-        close(cgi_session_.readFd);
+        fd::Fd::close(cgi_session_.readFd);
     }
     if (cgi_session_.writeFd != -1) {
         event_.del(cgi_session_.writeFd);
-        close(cgi_session_.writeFd);
+        fd::Fd::close(cgi_session_.writeFd);
     }
     if (cgi_session_.pid != -1) {
         kill(cgi_session_.pid, SIGKILL);
@@ -118,7 +119,7 @@ void ClientHandler::on_close() {
         cgi_session_.pid = -1;
     }
     event_.del(fd_);
-    ::close(fd_);
+    fd::Fd::close(fd_);
     delete this;
 }
 
@@ -198,7 +199,7 @@ void ClientHandler::on_readable() {
                                    ClientHandler::on_event),
                                this);
                 } else {
-                    close(cgi_session_.writeFd);
+                    fd::Fd::close(cgi_session_.writeFd);
                     cgi_session_.writeFd = -1;
                 }
 
@@ -281,12 +282,12 @@ void ClientHandler::on_cgi_read() {
     } else {
         if (cgi_session_.readFd != -1) {
             event_.del(cgi_session_.readFd);
-            close(cgi_session_.readFd);
+            fd::Fd::close(cgi_session_.readFd);
             cgi_session_.readFd = -1;
         }
         if (cgi_session_.writeFd != -1) {
             event_.del(cgi_session_.writeFd);
-            close(cgi_session_.writeFd);
+            fd::Fd::close(cgi_session_.writeFd);
             cgi_session_.writeFd = -1;
         }
 
@@ -300,12 +301,12 @@ void ClientHandler::finish_cgi_process() {
 
     if (fd != -1) {
         event_.del(fd);
-        close(fd);
+        fd::Fd::close(fd);
         cgi_session_.readFd = -1;
     }
     if (cgi_session_.writeFd != -1) {
         event_.del(cgi_session_.writeFd);
-        close(cgi_session_.writeFd);
+        fd::Fd::close(cgi_session_.writeFd);
         cgi_session_.writeFd = -1;
     }
 

--- a/src/http/ResolveConfig.cpp
+++ b/src/http/ResolveConfig.cpp
@@ -60,7 +60,7 @@ void ResolveConfig::resolve_error_pages_internal(  // NOLINT
                   .target[error_page_directive.target.size() - 1] == '/')) {
             std::string absolute_path = base_root + error_page_directive.target;
             try {
-                Fd fd(absolute_path.c_str(), O_RDONLY);
+                fd::Fd fd(absolute_path.c_str(), O_RDONLY);
                 error_page_directive.target = absolute_path;
             } catch (std::runtime_error& e) {
                 std::cerr << e.what() << '\n';
@@ -75,7 +75,7 @@ void ResolveConfig::resolve_error_pages_internal(  // NOLINT
             std::string absolute_path =
                 base_root + error_page_directive.target + *index;
             try {
-                Fd fd(absolute_path.c_str(), O_RDONLY);
+                fd::Fd fd(absolute_path.c_str(), O_RDONLY);
                 error_page_directive.target = absolute_path;
                 found = true;
                 break;

--- a/src/http/ResponseFactory.cpp
+++ b/src/http/ResponseFactory.cpp
@@ -9,6 +9,7 @@
 #include <stdexcept>
 
 #include "../core/Fd.h"
+#include "../core/FdException.h"
 #include "HttpParser.h"
 #include "MimeTypes.h"
 #include "Router.h"

--- a/src/http/ResponseFactory.cpp
+++ b/src/http/ResponseFactory.cpp
@@ -83,9 +83,9 @@ HttpResponse ResponseFactory::render_error(int status_code,
 
     std::vector<char> buffer;
     try {
-        Fd fd(error_page_directive.target.c_str(), O_RDONLY);
-        buffer = fd.FreadAll();
-    } catch (const OpenException& e) {
+        fd::Fd fd(error_page_directive.target.c_str(), O_RDONLY);
+        fd.readAll(buffer);
+    } catch (const fd::Exception& e) {
         std::cerr << e.what() << '\n';
         return render_default_error_page(status_code);
     }
@@ -116,9 +116,9 @@ std::string ResponseFactory::find_index_files(const HttpRequest& request,
         }
         std::vector<char> buffer;
         try {
-            Fd fd(path_name.c_str(), O_RDONLY);
-            buffer = fd.FreadAll();
-        } catch (const OpenException& e) {
+            fd::Fd fd(path_name.c_str(), O_RDONLY);
+            fd.readAll(buffer);
+        } catch (const fd::Exception& e) {
             std::cerr << e.what() << '\n';
             continue;
         }
@@ -143,9 +143,9 @@ std::string ResponseFactory::find_root_files(const HttpRequest& request,
 
     std::vector<char> buffer;
     try {
-        Fd fd(path_name.c_str(), O_RDONLY);
-        buffer = fd.FreadAll();
-    } catch (const OpenException& e) {
+        fd::Fd fd(path_name.c_str(), O_RDONLY);
+        fd.readAll(buffer);
+    } catch (const fd::Exception& e) {
         std::cerr << e.what() << '\n';
         return "";
     }
@@ -212,8 +212,8 @@ HttpResponse ResponseFactory::response_post(const HttpRequest& request,
     std::string filename = ss.str();
     std::string fullpath = dir + filename;
     try {
-        Fd fd(fullpath.c_str(), O_CREAT | O_WRONLY | O_TRUNC);
-        fd.FwriteAll(request.body_);
+        fd::Fd fd(fullpath.c_str(), O_CREAT | O_WRONLY | O_TRUNC);
+        fd.writeAll(request.body_);
     } catch (const std::runtime_error& e) {
         std::cerr << e.what() << '\n';
         return render_error(HttpStatus::InternalServerError, route);


### PR DESCRIPTION
## 概要
Fd 関係のクラスのリファクタリング
<!-- Issue があれば記載 -->
<!-- PRの概要と実施背景を記載 -->
## フィードバックメモ
- ファイルのアクセス権限を設定する際は umask でユーザーの環境で制限をかけることを前提として、実装はフル権限をデフォルトにしてあげた方がよい
- クラスヘッダ
    - 静的変数, プライベート変数, パブリックメソッドの順番で定義する（開発者が知りたい情報の順番で定義する）
    - 定義する際は意味の塊ごとに改行で区切る（静的変数とプライベート変数の間など）
- メソッドの実装
    - 戻り値で `std::vector` を返すと毎回コンストラクタが走るため、呼び出し側で入れ物を用意して、引数で参照渡しするのがよい
    - 引数で受け取った際は関数側で `clear` して空の状態を保証する
- 命名
    - 名前空間で区切っていれば関数・変数名でプレフィックスを入れる必要はない
    - プライベート変数のサフィックスに `_` をつけているが、`this->variable` の形でアクセスすることを徹底すればプライベート変数ということは一目でわかるため、サフィックス出つけるメリットは薄い
- エラーメッセージ
    - `std::string("message").append(info);` のような形がよい
- 初期化リストは変数を `const` で定義してる時のみ使用する
- 基本的には `{}` の中で処理を書いた方が保守性が高い（初期化するだけであれば初期化リストでいいが、追加でやりたいことが増えた時に初期化リストだと対応しにくいため）
- fd, socket, pipe をどう扱うかに関して
    - 基底クラスに `Fd` を定義し、`socket` や `pipe` で `Fd` を継承し、独自の実装を追加する形がよい
    - Fd 関連はすべて RAII を徹底する
    - すべて `namespace fd` の中に定義する